### PR TITLE
make using venv in dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.15.9 (Aug 10, 2021)
+
+### Changed
+
+* Dockerfile uses venv to set up dependencies, run app.
+
+  
 ## 0.15.8 (Aug 09, 2021)
 
 ### Fixed

--- a/{{cookiecutter.bot_project_name}}/Dockerfile
+++ b/{{cookiecutter.bot_project_name}}/Dockerfile
@@ -1,34 +1,44 @@
 FROM python:3.9-slim
 
+EXPOSE 8000
+
 ENV PYTHONUNBUFFERED 1
 ENV UVICORN_CMD_ARGS ""
-
-ARG NON_ROOT_USER=express_bot
-RUN useradd --create-home ${NON_ROOT_USER}
-
-EXPOSE 8000
-WORKDIR /app
-
-COPY poetry.lock pyproject.toml ./
+ENV APP_USER=appuser
 
 ARG CI_JOB_TOKEN=""
 ARG GIT_HOST=""
 ARG GIT_PASSWORD=${CI_JOB_TOKEN}
 ARG GIT_LOGIN="gitlab-ci-token"
 
+
 # Poetry can't read password to download private repos
 RUN echo -e "machine ${GIT_HOST}\nlogin ${GIT_LOGIN}\npassword ${GIT_PASSWORD}" > ~/.netrc && \
     apt-get update && \
     apt-get install -y git sudo && \
-    pip install poetry==1.1.6 --no-cache-dir && \
-    poetry config virtualenvs.create false && \
-    poetry install --no-dev && \
-    echo "${NON_ROOT_USER} ALL = NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/express_bot && \
-    rm -rf /root/.cache/pypoetry && \
+    echo "${APP_USER} ALL = NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates && \
     rm -rf ~/.netrc && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+
+RUN useradd --create-home $APP_USER
+WORKDIR /home/$APP_USER
+USER $APP_USER
+
+CMD update-ca-certificates
+
+ENV VENV_PATH=/home/$APP_USER/.venv/bin
+ENV USER_PATH=/home/$APP_USER/.local/bin
+ENV PATH="$VENV_PATH:$USER_PATH:$PATH"
+
+COPY poetry.lock pyproject.toml ./
+
+RUN pip install --user --no-cache-dir poetry==1.1.6 && \
+    poetry config virtualenvs.in-project false && \
+    poetry install --no-dev && \
+    rm -rf ~/.cache/pypoetry
 
 COPY alembic.ini .
 COPY app app
@@ -36,8 +46,5 @@ COPY app app
 ARG CI_COMMIT_SHA=""
 ENV GIT_COMMIT_SHA=${CI_COMMIT_SHA}
 
-USER ${NON_ROOT_USER}
-
-CMD sudo update-ca-certificates && \
-    alembic upgrade head && \
+CMD alembic upgrade head && \
     uvicorn --host=0.0.0.0 $UVICORN_CMD_ARGS app.main:app

--- a/{{cookiecutter.bot_project_name}}/Dockerfile
+++ b/{{cookiecutter.bot_project_name}}/Dockerfile
@@ -1,34 +1,44 @@
 FROM python:3.9-slim
 
+EXPOSE 8000
+
 ENV PYTHONUNBUFFERED 1
 ENV UVICORN_CMD_ARGS ""
-
-ARG NON_ROOT_USER=express_bot
-RUN useradd --create-home ${NON_ROOT_USER}
-
-EXPOSE 8000
-WORKDIR /app
-
-COPY poetry.lock pyproject.toml ./
+ENV APP_USER=appuser
 
 ARG CI_JOB_TOKEN=""
 ARG GIT_HOST=""
 ARG GIT_PASSWORD=${CI_JOB_TOKEN}
 ARG GIT_LOGIN="gitlab-ci-token"
 
+
 # Poetry can't read password to download private repos
 RUN echo -e "machine ${GIT_HOST}\nlogin ${GIT_LOGIN}\npassword ${GIT_PASSWORD}" > ~/.netrc && \
     apt-get update && \
     apt-get install -y git sudo && \
-    pip install poetry==1.1.6 --no-cache-dir && \
-    poetry config virtualenvs.create false && \
-    poetry install --no-dev && \
-    echo "${NON_ROOT_USER} ALL = NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/express_bot && \
-    rm -rf /root/.cache/pypoetry && \
+    echo "${APP_USER} ALL = NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates && \
+    sudo update-ca-certificates && \
+    rm -rf ~/.cache/pypoetry && \
     rm -rf ~/.netrc && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+
+RUN useradd --create-home $APP_USER
+WORKDIR /home/$APP_USER
+USER $APP_USER
+
+ENV VENV_PATH=/home/$APP_USER/.venv/bin
+ENV USER_PATH=/home/$APP_USER/.local/bin
+ENV PATH="$VENV_PATH:$USER_PATH:$PATH"
+
+RUN pip install --user --no-cache-dir poetry==1.1.6 && \
+    poetry config virtualenvs.in-project true
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --no-dev
 
 COPY alembic.ini .
 COPY app app
@@ -36,8 +46,5 @@ COPY app app
 ARG CI_COMMIT_SHA=""
 ENV GIT_COMMIT_SHA=${CI_COMMIT_SHA}
 
-USER ${NON_ROOT_USER}
-
-CMD sudo update-ca-certificates && \
-    alembic upgrade head && \
+CMD alembic upgrade head && \
     uvicorn --host=0.0.0.0 $UVICORN_CMD_ARGS app.main:app


### PR DESCRIPTION
Now venv is used in dockerfile to set up dependencies, run app  

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
