### PR TITLE
chore: Rename CI/CD jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.16.0 (Aug 16, 2021)
+
+### Changed
+
+* Rename CI/CD jobs `deploy.test` and `deploy.prod` to `deploy.botstest` and `deploy.botsprod`
+
+
 ## 0.15.9 (Aug 10, 2021)
 
 ### Changed

--- a/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
@@ -167,11 +167,11 @@ deploy.sandbox.stop:
   extends: deploy.sandbox
   script: *stop
 
-deploy.test:
+deploy.botstest:
   <<: *deploy_dev_config
   environment:
     name: test
-    on_stop: deploy.test.stop
+    on_stop: deploy.botstest.stop
   before_script:
     - *dev_env
     - *bot_project_name
@@ -182,12 +182,12 @@ deploy.test:
     - *storages
   script: *deploy
 
-deploy.test.stop:
+deploy.botstest.stop:
   <<: *deploy_stop_config
-  extends: deploy.test
+  extends: deploy.botstest
   script: *stop
 
-deploy.prod:
+deploy.botsprod:
   <<: *deploy_prod_config
   before_script:
     - *prod_env


### PR DESCRIPTION
# Description

Rename CI/CD jobs `deploy.test` and `deploy.prod` to `deploy.botstest` and `deploy.botsprod`

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
