### PR TITLE
new session for each db request

### DIFF
--- a/{{cookiecutter.bot_project_name}}/app/db/events.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/events.py
@@ -4,12 +4,12 @@ from typing import Optional
 from starlette.datastructures import URL
 
 from app.db.redis.repo import RedisRepo
-from app.db.sqlalchemy import session
+from app.db.sqlalchemy import async_db_connection
 
 
 async def init_db() -> None:
     """Create connection to db and init orm models."""
-    await session.init()
+    await async_db_connection.init()
 
 
 async def init_redis(
@@ -27,4 +27,4 @@ async def close_redis(redis: Optional[RedisRepo]) -> None:
 
 async def close_db() -> None:
     """Close connection to db."""
-    await session.close()
+    await async_db_connection.close()

--- a/{{cookiecutter.bot_project_name}}/app/db/models.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/models.py
@@ -2,10 +2,11 @@
 
 from typing import Any, Generic, List, TypeVar
 
-from sqlalchemy import Column, Integer, String, insert, update as _update
+from sqlalchemy import Column, Integer, String, delete, insert, update as _update
 from sqlalchemy.future import select
+from sqlalchemy.inspection import inspect
 
-from app.db.sqlalchemy import Base, session
+from app.db.sqlalchemy import Base, async_db_connection
 
 T = TypeVar("T")  # noqa: WPS111
 
@@ -13,31 +14,38 @@ T = TypeVar("T")  # noqa: WPS111
 class CRUDMixin(Generic[T]):
     """Mixin for CRUD operations for models."""
 
-    id: int  # noqa: WPS125
-
     @classmethod
     async def create(cls, **kwargs: Any) -> None:
         """Create object."""
         query = insert(cls).values(**kwargs)
+        session = await async_db_connection.get_session()
         async with session.begin():
             await session.execute(query)
+            await session.flush()
 
     @classmethod
-    async def update(cls, id: int, **kwargs: Any) -> None:  # noqa: WPS125
+    async def update(cls, pkey_val: Any, **kwargs: Any) -> None:  # noqa: WPS125
         """Update object by id."""
+        primary_key = inspect(cls).primary_key[0]
         query = (
             _update(cls)
-            .where(cls.id == id)
+            .where(primary_key == pkey_val)
             .values(**kwargs)
             .execution_options(synchronize_session="fetch")
         )
+
+        session = await async_db_connection.get_session()
         async with session.begin():
             await session.execute(query)
+            await session.flush()
 
     @classmethod
-    async def get(cls, id: int) -> T:  # noqa: WPS125
+    async def get(cls, pkey_val: Any) -> T:  # noqa: WPS125
         """Get object by id."""
-        query = select(cls).where(cls.id == id)
+        primary_key = inspect(cls).primary_key[0]
+        query = select(cls).where(primary_key == pkey_val)
+
+        session = await async_db_connection.get_session()
         async with session.begin():
             rows = await session.execute(query)
         return rows.scalars().one()
@@ -46,9 +54,21 @@ class CRUDMixin(Generic[T]):
     async def all(cls) -> List[T]:  # noqa: WPS125
         """Get all objects."""
         query = select(cls)
+        session = await async_db_connection.get_session()
         async with session.begin():
             rows = await session.execute(query)
         return rows.scalars().all()
+
+    @classmethod
+    async def delete(cls, pkey_val: Any) -> Any:
+        """Delete object by primary key value."""
+        primary_key = inspect(cls).primary_key[0]
+        query = delete(cls).where(primary_key == pkey_val)
+
+        session = await async_db_connection.get_session()
+        async with session.begin():
+            await session.execute(query)
+            await session.flush()
 
 
 class Record(Base, CRUDMixin):


### PR DESCRIPTION
# Description

New session is created for each db request (like CRUD is implemented now)

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
