### PR TITLE
change way sqlalchemy used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.19.0 (Nov 14, 2021)
+
+### Changed
+
+* Changed the way sqlalchemy is used
+
+
 ## 0.18.0 (Sep 22, 2021)
 
 ### Added

--- a/{{cookiecutter.bot_project_name}}/app/bot/dependencies/db.py
+++ b/{{cookiecutter.bot_project_name}}/app/bot/dependencies/db.py
@@ -1,0 +1,12 @@
+"""Dependency related to database."""
+
+from botx import Bot, Depends
+
+from app.db.sqlalchemy import AsyncSessionFactory
+
+
+def get_session_factory(bot: Bot) -> AsyncSessionFactory:
+    return bot.state.session_factory
+
+
+session_factory_dependency = Depends(get_session_factory)

--- a/{{cookiecutter.bot_project_name}}/app/db/events.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/events.py
@@ -4,12 +4,16 @@ from typing import Optional
 from starlette.datastructures import URL
 
 from app.db.redis.repo import RedisRepo
-from app.db.sqlalchemy import async_db_connection
+from app.db.sqlalchemy import AsyncSessionFactory, build_db_session_factory
 
 
-async def init_db() -> None:
+async def init_db() -> AsyncSessionFactory:
     """Create connection to db and init orm models."""
-    await async_db_connection.init()
+    return build_db_session_factory()
+
+
+async def close_db() -> None:
+    """Close connection to db."""
 
 
 async def init_redis(
@@ -23,8 +27,3 @@ async def close_redis(redis: Optional[RedisRepo]) -> None:
     """Close redis connections."""
     if redis:
         await redis.close()
-
-
-async def close_db() -> None:
-    """Close connection to db."""
-    await async_db_connection.close()

--- a/{{cookiecutter.bot_project_name}}/app/db/models.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/models.py
@@ -1,77 +1,11 @@
 """Database models declarations."""
 
-from typing import Any, Generic, List, TypeVar
+from sqlalchemy import Column, Integer, String
 
-from sqlalchemy import Column, Integer, String, delete, insert, update as _update
-from sqlalchemy.future import select
-from sqlalchemy.inspection import inspect
-
-from app.db.sqlalchemy import Base, async_db_connection
-
-T = TypeVar("T")  # noqa: WPS111
+from app.db.sqlalchemy import Base
 
 
-class CRUDMixin(Generic[T]):
-    """Mixin for CRUD operations for models."""
-
-    @classmethod
-    async def create(cls, **kwargs: Any) -> None:
-        """Create object."""
-        query = insert(cls).values(**kwargs)
-        session = await async_db_connection.get_session()
-        async with session.begin():
-            await session.execute(query)
-            await session.flush()
-
-    @classmethod
-    async def update(cls, pkey_val: Any, **kwargs: Any) -> None:  # noqa: WPS125
-        """Update object by id."""
-        primary_key = inspect(cls).primary_key[0]
-        query = (
-            _update(cls)
-            .where(primary_key == pkey_val)
-            .values(**kwargs)
-            .execution_options(synchronize_session="fetch")
-        )
-
-        session = await async_db_connection.get_session()
-        async with session.begin():
-            await session.execute(query)
-            await session.flush()
-
-    @classmethod
-    async def get(cls, pkey_val: Any) -> T:  # noqa: WPS125
-        """Get object by id."""
-        primary_key = inspect(cls).primary_key[0]
-        query = select(cls).where(primary_key == pkey_val)
-
-        session = await async_db_connection.get_session()
-        async with session.begin():
-            rows = await session.execute(query)
-        return rows.scalars().one()
-
-    @classmethod
-    async def all(cls) -> List[T]:  # noqa: WPS125
-        """Get all objects."""
-        query = select(cls)
-        session = await async_db_connection.get_session()
-        async with session.begin():
-            rows = await session.execute(query)
-        return rows.scalars().all()
-
-    @classmethod
-    async def delete(cls, pkey_val: Any) -> Any:
-        """Delete object by primary key value."""
-        primary_key = inspect(cls).primary_key[0]
-        query = delete(cls).where(primary_key == pkey_val)
-
-        session = await async_db_connection.get_session()
-        async with session.begin():
-            await session.execute(query)
-            await session.flush()
-
-
-class Record(Base, CRUDMixin):
+class Record(Base):
     """Simple database model for example."""
 
     __tablename__ = "record"

--- a/{{cookiecutter.bot_project_name}}/app/db/repos/record_repo.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/repos/record_repo.py
@@ -1,0 +1,28 @@
+"""Record repo."""
+
+from sqlalchemy import insert, select
+
+from app.db.models import Record
+from app.db.sqlalchemy import AsyncSession
+
+
+class RecordRepo:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def create_record(
+        self,
+        text: str,
+    ) -> None:
+        """Create record row in db."""
+        query = insert(Record).values(record_data=text)
+        await self._session.execute(query)
+
+    async def get_all(  # noqa: WPS218
+        self,
+    ) -> list[Record]:
+        """Get all objects."""
+        query = select(Record)
+
+        rows = await self._session.execute(query)
+        return rows.scalars().all()

--- a/{{cookiecutter.bot_project_name}}/app/db/sqlalchemy.py
+++ b/{{cookiecutter.bot_project_name}}/app/db/sqlalchemy.py
@@ -1,8 +1,7 @@
 """SQLAlchemy helpers."""
 
-from typing import Any
+from typing import Callable
 
-from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -10,6 +9,7 @@ from app.settings.config import get_app_settings
 
 POSTGRES_DSN = get_app_settings().POSTGRES_DSN
 SQL_DEBUG = get_app_settings().SQL_DEBUG
+AsyncSessionFactory = Callable[..., AsyncSession]
 
 
 def make_url_async(url: str) -> str:
@@ -25,38 +25,6 @@ def make_url_sync(url: str) -> str:
 Base = declarative_base()
 
 
-class AsyncDatabaseConnectionFabric:
-    """Database session class."""
-
-    def __init__(self) -> None:
-        """Initialize."""
-        self._session_maker = None
-        self._engine = None
-
-    def __getattr__(self, name: str) -> Any:
-        """Get session attrs by default."""
-        return getattr(self._session, name)
-
-    async def init(self) -> None:
-        """Async initialization."""
-        if not POSTGRES_DSN:
-            logger.warning("Database NOT initialized")
-            return
-        self._engine = create_async_engine(make_url_async(POSTGRES_DSN), echo=SQL_DEBUG)
-
-        self._session_maker = sessionmaker(
-            self._engine, expire_on_commit=False, class_=AsyncSession
-        )
-
-    async def close(self) -> None:
-        """Close database connections."""
-        assert self._engine is not None
-        await self._engine.dispose()
-
-    async def get_session(self) -> Any:
-        """Return new session."""
-        assert self._session_maker is not None
-        return self._session_maker()
-
-
-async_db_connection = AsyncDatabaseConnectionFabric()
+def build_db_session_factory() -> AsyncSessionFactory:
+    engine = create_async_engine(make_url_async(POSTGRES_DSN), echo=SQL_DEBUG)
+    return sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)

--- a/{{cookiecutter.bot_project_name}}/app/settings/events.py
+++ b/{{cookiecutter.bot_project_name}}/app/settings/events.py
@@ -21,8 +21,8 @@ def startup(redis_dsn: str, redis_prefix: str, bot_app: Bot) -> Callable:
     async def start_app() -> None:  # noqa: WPS430
         configure_logger()
         await bot_app.start()
-        await init_db()
         bot_app.state.redis = await init_redis(redis_dsn, redis_prefix)
+        bot_app.state.session_factory = await init_db()
 
     return start_app
 


### PR DESCRIPTION
# Description

The way sqlalchemy and sessions used is changed

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
