### PR TITLE
fix: add exception handling to endpoints api.

### DIFF
--- a/{{cookiecutter.bot_project_name}}/pyproject.toml
+++ b/{{cookiecutter.bot_project_name}}/pyproject.toml
@@ -10,7 +10,7 @@ authors = []
 [tool.poetry.dependencies]
 python = "~3.10"
 
-botx = { git = "https://github.com/ExpressApp/pybotx", rev = "ed479be" }
+botx = { git = "https://github.com/ExpressApp/pybotx", rev = "e9155bd" }
 # TODO: Add pybotx-fsm
 
 fastapi = "~0.70.1"

--- a/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
+++ b/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
@@ -1,0 +1,285 @@
+from http import HTTPStatus
+from uuid import UUID
+
+import respx
+from fastapi.testclient import TestClient
+import httpx
+
+from botx import Bot
+from app.main import get_application
+
+
+@respx.mock
+def test__web_app__bot_status(
+    bot_id: UUID,
+    bot: Bot,
+) -> None:
+    # - Arrange -
+    query_params = {
+        "bot_id": str(bot_id),
+        "chat_type": "chat",
+        "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+    }
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        response = test_client.get(
+            "/status",
+            params=query_params,
+        )
+
+    # - Assert -
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {
+        "result": {
+            "commands": [
+                {'body': '/help',
+                 'description': 'Get available commands',
+                 'name': '/help',
+                 }
+
+            ],
+            "enabled": True,
+            "status_message": "Bot is working",
+        },
+        "status": "ok",
+    }
+
+
+@respx.mock
+def test__web_app__bot_status_unknown_bot_failed(
+    bot_id: UUID,
+    bot: Bot,
+) -> None:
+    query_params = {
+        "bot_id": "f3e176d5-ff46-4b18-b260-25008338c06e",
+        "chat_type": "chat",
+        "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+    }
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        response = test_client.get(
+            "/status",
+            params=query_params,
+        )
+
+    # - Assert -
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+@respx.mock
+def test__web_app__bot_command(
+    bot_id: UUID,
+    host: str,
+    bot: Bot,
+) -> None:
+    # - Arrange -
+    direct_notification_endpoint = respx.post(
+        f"https://{host}/api/v4/botx/notifications/direct",
+    ).mock(
+        return_value=httpx.Response(
+            HTTPStatus.ACCEPTED,
+            json={
+                "status": "ok",
+                "result": {"sync_id": "21a9ec9e-f21f-4406-ac44-1a78d2ccf9e3"},
+            },
+        ),
+    )
+
+    command_payload = {
+        "bot_id": str(bot_id),
+        "command": {
+            "body": "/debug",
+            "command_type": "user",
+            "data": {},
+            "metadata": {},
+        },
+        "attachments": [],
+        "async_files": [],
+        "entities": [],
+        "source_sync_id": None,
+        "sync_id": "6f40a492-4b5f-54f3-87ee-77126d825b51",
+        "from": {
+            "ad_domain": None,
+            "ad_login": None,
+            "app_version": None,
+            "chat_type": "chat",
+            "device": None,
+            "device_meta": {
+                "permissions": None,
+                "pushes": False,
+                "timezone": "Europe/Moscow",
+            },
+            "device_software": None,
+            "group_chat_id": "30dc1980-643a-00ad-37fc-7cc10d74e935",
+            "host": "cts.example.com",
+            "is_admin": True,
+            "is_creator": True,
+            "locale": "en",
+            "manufacturer": None,
+            "platform": None,
+            "platform_package_id": None,
+            "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+            "username": None,
+        },
+        "proto_version": 4,
+    }
+
+    callback_payload = {
+        "status": "ok",
+        "sync_id": "21a9ec9e-f21f-4406-ac44-1a78d2ccf9e3",
+        "result": {},
+    }
+
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        command_response = test_client.post(
+            "/command",
+            json=command_payload,
+        )
+
+        callback_response = test_client.post(
+            "/notification/callback",
+            json=callback_payload,
+        )
+
+    # - Assert -
+    assert command_response.status_code == HTTPStatus.ACCEPTED
+    assert direct_notification_endpoint.called
+    assert callback_response.status_code == HTTPStatus.ACCEPTED
+
+
+@respx.mock
+def test__web_app__bot_command_failed(
+    bot_id: UUID,
+    host: str,
+    bot: Bot,
+) -> None:
+    # - Arrange -
+    direct_notification_endpoint = respx.post(
+        f"https://{host}/api/v4/botx/notifications/direct",
+    ).mock(
+        return_value=httpx.Response(
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            json={
+                "status": "ok",
+                "result": {"sync_id": "21a9ec9e-f21f-4406-ac44-1a78d2ccf9e3"},
+            },
+        ),
+    )
+
+    command_payload = {
+        "bot_id": str(bot_id),
+        "command": {
+            "body": "/test",
+            "command_type": "user",
+            "data": {},
+            "metadata": {},
+        },
+        "attachments": [],
+        "async_files": [],
+        "entities": [],
+        "source_sync_id": None,
+        "sync_id": "6f40a492-4b5f-54f3-87ee-77126d825b51",
+        "from": {
+            "ad_domain": None,
+            "ad_login": None,
+            "app_version": None,
+            "chat_type": "chat",
+            "device": None,
+            "device_meta": {
+                "permissions": None,
+                "pushes": False,
+                "timezone": "Europe/Moscow",
+            },
+            "device_software": None,
+            "group_chat_id": "30dc1980-643a-00ad-37fc-7cc10d74e935",
+            "host": "cts.example.com",
+            "is_admin": True,
+            "is_creator": True,
+            "locale": "en",
+            "manufacturer": None,
+            "platform": None,
+            "platform_package_id": None,
+            "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+            "username": None,
+        },
+        "proto_version": 4,
+    }
+
+    callback_payload = {
+        "status": "ok",
+        "sync_id": "21a9ec9e-f21f-4406-ac44-1a78d2ccf9e3",
+        "result": {},
+    }
+
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        command_response = test_client.post(
+            "/command",
+            json=command_payload,
+        )
+
+        callback_response = test_client.post(
+            "/notification/callback",
+            json=callback_payload,
+        )
+
+    # - Assert -
+    assert command_response.status_code == HTTPStatus.ACCEPTED
+    assert direct_notification_endpoint.called
+    assert callback_response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+@respx.mock
+def test__web_app__unknown_bot_response(
+    bot: Bot,
+) -> None:
+    # - Arrange -
+    payload = {
+        "bot_id": "c755e147-30a5-45df-b46a-c75aa6089c8f",
+        "command": {
+            "body": "/debug",
+            "command_type": "user",
+            "data": {},
+            "metadata": {},
+        },
+        "attachments": [],
+        "async_files": [],
+        "entities": [],
+        "source_sync_id": None,
+        "sync_id": "6f40a492-4b5f-54f3-87ee-77126d825b51",
+        "from": {
+            "ad_domain": None,
+            "ad_login": None,
+            "app_version": None,
+            "chat_type": "chat",
+            "device": None,
+            "device_meta": {
+                "permissions": None,
+                "pushes": False,
+                "timezone": "Europe/Moscow",
+            },
+            "device_software": None,
+            "group_chat_id": "30dc1980-643a-00ad-37fc-7cc10d74e935",
+            "host": "cts.example.com",
+            "is_admin": True,
+            "is_creator": True,
+            "locale": "en",
+            "manufacturer": None,
+            "platform": None,
+            "platform_package_id": None,
+            "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+            "username": None,
+        },
+        "proto_version": 4,
+    }
+
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        response = test_client.post(
+            "/command",
+            json=payload,
+        )
+
+    # - Assert -
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE


### PR DESCRIPTION
# Description

Add exception handling to endpoints api.

# Checklist

- [ ] I've generated a new bot from the async-box template and checked that everything works:
  - [ ] Linters and tests have passed
  - [ ] Bot answers on `/help` command
  - [ ] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
