### PR TITLE
ci: Using cache from previous docker-image build

### DIFF
--- a/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
@@ -92,7 +92,9 @@ build:
     - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN $CI_REGISTRY
     - CONTAINER_RELEASE_IMAGE="$CI_REGISTRY_IMAGE:${CI_COMMIT_TAG:-$CI_COMMIT_REF_SLUG}"
   script:
+    - docker pull $CONTAINER_RELEASE_IMAGE || true
     - docker build
+      --cache-from $CONTAINER_RELEASE_IMAGE
       --build-arg GIT_HOST=$GIT_HOST
       --build-arg CI_JOB_TOKEN=$CI_JOB_TOKEN
       --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA


### PR DESCRIPTION
# Description

Please include a summary of the change.

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
