### PR TITLE
fix: Can't disable debug logs from botx

### DIFF
--- a/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.bot_project_name}}/.gitlab-ci.yml
@@ -15,6 +15,7 @@
     -e POSTGRES_DSN="${POSTGRES_DSN}"
     -e REDIS_DSN="${REDIS_DSN}"
     -e BOT_CREDENTIALS="${BOT_CREDENTIALS}"
+    -e DEBUG="${DEBUG:-false}"
     $CONTAINER_RELEASE_IMAGE
 
 .create_db: &create_db

--- a/{{cookiecutter.bot_project_name}}/app/logger.py
+++ b/{{cookiecutter.bot_project_name}}/app/logger.py
@@ -1,6 +1,7 @@
 """Configured application logger."""
 
 import logging
+import sys
 from typing import TYPE_CHECKING
 
 from loguru import logger as _logger
@@ -33,14 +34,26 @@ class InterceptHandler(logging.Handler):
 
 
 def setup_logger() -> "Logger":
-    # Intercept everything at the root logger
-    logging.root.handlers = [InterceptHandler()]
-    logging.root.setLevel(logging.DEBUG if settings.DEBUG else logging.INFO)
-
-    # Remove every other logger's handlers and propagate to root logger
+    # Remove every logger's handlers and propagate to root logger
     for name in logging.root.manager.loggerDict.keys():
         logging.getLogger(name).handlers = []
         logging.getLogger(name).propagate = True
+
+    # Intercept everything at the root logger
+    logging.basicConfig(handlers=[InterceptHandler()], level=0)
+
+    # Enable botx logger
+    _logger.enable("botx")
+
+    # Setup loguru main logger
+    _logger.configure(
+        handlers=[
+            {
+                "sink": sys.stdout,
+                "level": logging.DEBUG if settings.DEBUG else logging.INFO,
+            }
+        ],
+    )
 
     return _logger
 


### PR DESCRIPTION
# Description

Now you can disable debug logs from pybotx

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
