### PR TITLE
fix: Add exception handler if no params passed to endpoint status.

### DIFF
--- a/{{cookiecutter.bot_project_name}}/app/api/endpoints/botx.py
+++ b/{{cookiecutter.bot_project_name}}/app/api/endpoints/botx.py
@@ -84,14 +84,22 @@ async def status_handler(request: Request, bot: Bot = bot_dependency) -> JSONRes
 
     try:
         status = await bot.raw_get_status(dict(request.query_params))
+
     except UnknownBotAccountError as exc:
         error_label = f"Unknown bot_id: {exc.bot_id}"
-        logger.warning(error_label)
-
+        logger.warning(exc)
         return JSONResponse(
             build_bot_disabled_response(error_label),
             status_code=HTTPStatus.SERVICE_UNAVAILABLE,
         )
+
+    except ValueError:
+        error_label = "Invalid params"
+        logger.warning(error_label)
+        return JSONResponse(
+            build_bot_disabled_response(error_label), status_code=HTTPStatus.BAD_REQUEST
+        )
+
     return JSONResponse(status)
 
 

--- a/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
+++ b/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
@@ -70,6 +70,25 @@ def test__web_app__bot_status_unknown_bot_response_service_unavailable(
 
 
 @respx.mock
+def test__web_app__bot_status_without_parameters_response_bad_request(
+    bot_id: UUID,
+    bot: Bot,
+) -> None:
+    # - Arrange -
+    query_params = {}
+
+    # - Act -
+    with TestClient(get_application()) as test_client:
+        response = test_client.get(
+            "/status",
+            params=query_params,
+        )
+
+    # - Assert -
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@respx.mock
 def test__web_app__bot_command_response_accepted(
     bot_id: UUID,
     host: str,


### PR DESCRIPTION
# Description

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
