### PR TITLE
fix: Enable linters for tests

### DIFF
--- a/{{cookiecutter.bot_project_name}}/scripts/format
+++ b/{{cookiecutter.bot_project_name}}/scripts/format
@@ -5,6 +5,6 @@ set -ex
 autoflake --recursive --in-place \
   --remove-all-unused-imports \
   --ignore-init-module-imports \
-  app
-isort --profile black app
-black app
+  app tests
+isort --profile black app tests
+black app tests

--- a/{{cookiecutter.bot_project_name}}/scripts/lint
+++ b/{{cookiecutter.bot_project_name}}/scripts/lint
@@ -2,8 +2,8 @@
 
 set -ex
 
-black --check --diff app
-isort --profile black --check-only app
+black --check --diff app tests
+isort --profile black --check-only app tests
 
-mypy app
-flake8 app
+mypy app tests
+flake8 app tests

--- a/{{cookiecutter.bot_project_name}}/setup.cfg
+++ b/{{cookiecutter.bot_project_name}}/setup.cfg
@@ -82,7 +82,7 @@ per-file-ignores =
     app/bot/dependencies/external_cts.py:WPS232
 # line too long
     app/resources/strings.py:E501
-    tests/*:D100,WPS110,WPS201,WPS235,WPS430,WPS442
+    tests/*:D100,WPS110,WPS116,WPS118,WPS201,WPS204,WPS235,WPS430,WPS442
 # too many public attrs
 # too many args
 # wrong var name
@@ -130,6 +130,8 @@ ignore =
     # WPSxxx
     # Allow upper-case constants
     WPS115,
+    # Too many module members
+    WPS202,
     # Too many methods in class
     WPS214,
     # Does not play well with forward type references

--- a/{{cookiecutter.bot_project_name}}/tests/test_commands/test_common.py
+++ b/{{cookiecutter.bot_project_name}}/tests/test_commands/test_common.py
@@ -18,14 +18,13 @@ from pybotx import (
     OutgoingMessage,
     UserKinds,
 )
+from pybotx.models.attachments import AttachmentVideo
 from pybotx.models.commands import BotCommand
 from sqlalchemy.ext.asyncio import AsyncSession
-from pybotx.models.attachments import AttachmentVideo
 
 from app.caching.redis_repo import RedisRepo
 from app.db.record.repo import RecordRepo
 from app.schemas.record import Record
-
 
 
 async def test_answer_error_exception_middleware(
@@ -257,7 +256,7 @@ async def test_chat_created_handler(
     # - Assert -
     bot.answer_message.assert_awaited_once_with(
         (
-            f"Вас приветствует {{cookiecutter.bot_display_name}}!\n\n"
+            "Вас приветствует {{cookiecutter.bot_display_name}}!\n\n"
             "Для более подробной информации нажмите кнопку `/help`"
         ),
         bubbles=BubbleMarkup([[Button(command="/help", label="/help")]]),

--- a/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
+++ b/{{cookiecutter.bot_project_name}}/tests/test_endpoints/test_botx.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from typing import Dict
 from uuid import UUID
 
 import httpx
@@ -33,11 +34,11 @@ def test__web_app__bot_status_response_ok(
     assert response.json() == {
         "result": {
             "commands": [
-                {'body': '/help',
-                 'description': 'Get available commands',
-                 'name': '/help',
-                 }
-
+                {
+                    "body": "/help",
+                    "description": "Get available commands",
+                    "name": "/help",
+                }
             ],
             "enabled": True,
             "status_message": "Bot is working",
@@ -75,7 +76,7 @@ def test__web_app__bot_status_without_parameters_response_bad_request(
     bot: Bot,
 ) -> None:
     # - Arrange -
-    query_params = {}
+    query_params: Dict[str, str] = {}
 
     # - Act -
     with TestClient(get_application()) as test_client:

--- a/{{cookiecutter.bot_project_name}}/tests/test_services/test_botx_user_search.py
+++ b/{{cookiecutter.bot_project_name}}/tests/test_services/test_botx_user_search.py
@@ -1,10 +1,10 @@
-from uuid import UUID
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 from pybotx import Bot, UserFromSearch, UserNotFoundError
 
-from app.services.botx_user_search import search_user_on_each_cts, UserIsBotError
+from app.services.botx_user_search import UserIsBotError, search_user_on_each_cts
 
 
 async def test_search_user_on_each_cts_user_is_bot_error_raised(
@@ -36,10 +36,12 @@ async def test_search_user_on_each_cts_not_found(
     bot.search_user_by_huid = AsyncMock(side_effect=UserNotFoundError("not found"))
 
     # - Act -
-    found_user = await search_user_on_each_cts(bot, UUID("86c4814b-feee-4ff0-b04d-4b3226318078"))
+    search_result = await search_user_on_each_cts(
+        bot, UUID("86c4814b-feee-4ff0-b04d-4b3226318078")
+    )
 
     # - Assert -
-    assert found_user is None
+    assert search_result is None
 
 
 async def test_search_user_on_each_cts_suceed(
@@ -60,8 +62,13 @@ async def test_search_user_on_each_cts_suceed(
     bot.search_user_by_huid = AsyncMock(return_value=user)
 
     # - Act -
-    found_user, bot_account = await search_user_on_each_cts(bot, UUID("86c4814b-feee-4ff0-b04d-4b3226318078"))
+    search_result = await search_user_on_each_cts(
+        bot, UUID("86c4814b-feee-4ff0-b04d-4b3226318078")
+    )
 
     # - Assert -
+    assert search_result
+
+    found_user, bot_account = search_result
     assert found_user is user
     assert bot_account is list(bot.bot_accounts)[0]


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [ ] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
