### PR TITLE
fix: Hide autofilled `bot_name_underscored` in cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
 
   "bot_image_name_prefix": "registry.example.com/bots/",
 
-  "bot_name_underscored": "{{ cookiecutter.bot_project_name|replace('-', '_') }}",
+  "__bot_name_underscored": "{{ cookiecutter.bot_project_name|replace('-', '_') }}",
   "_copy_without_render": [
     ".venv"
   ]

--- a/{{cookiecutter.bot_project_name}}/advanced-deploy.md
+++ b/{{cookiecutter.bot_project_name}}/advanced-deploy.md
@@ -103,10 +103,10 @@ docker exec -it storages_postgres_1 psql --user postgres
 ```
 
 ```sql
-CREATE USER {{cookiecutter.bot_name_underscored}}_user PASSWORD '<GENERATE>';
-CREATE DATABASE {{cookiecutter.bot_name_underscored}}_db;
-GRANT ALL PRIVILEGES ON DATABASE {{cookiecutter.bot_name_underscored}}_db 
-  TO {{cookiecutter.bot_name_underscored}}_user;
+CREATE USER {{cookiecutter.__bot_name_underscored}}_user PASSWORD '<GENERATE>';
+CREATE DATABASE {{cookiecutter.__bot_name_underscored}}_db;
+GRANT ALL PRIVILEGES ON DATABASE {{cookiecutter.__bot_name_underscored}}_db 
+  TO {{cookiecutter.__bot_name_underscored}}_user;
 ```
 
 2. Скачайте репозиторий на сервер:

--- a/{{cookiecutter.bot_project_name}}/docker-compose.yml
+++ b/{{cookiecutter.bot_project_name}}/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: {{cookiecutter.bot_project_name}}
     environment:
       - BOT_CREDENTIALS=cts_host@secret_key@bot_id
-      - POSTGRES_DSN=postgres://postgres:postgres@{{cookiecutter.bot_project_name}}-postgres/{{cookiecutter.bot_name_underscored}}_db
+      - POSTGRES_DSN=postgres://postgres:postgres@{{cookiecutter.bot_project_name}}-postgres/{{cookiecutter.__bot_name_underscored}}_db
       - REDIS_DSN=redis://{{cookiecutter.bot_project_name}}-redis/0
       - DEBUG=true
     ports:
@@ -32,7 +32,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB={{cookiecutter.bot_name_underscored}}_db
+      - POSTGRES_DB={{cookiecutter.__bot_name_underscored}}_db
     restart: always
     volumes:
       - ./.storages/postgresdata:/var/lib/postgresql/data


### PR DESCRIPTION
# Checklist

- [ ] I've generated a new bot from the async-box template and checked that everything works:
  - [ ] Linters and tests have passed
  - [ ] Bot answers on `/help` command
  - [ ] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
