### PR TITLE
chore: bump pybotx version to 0.46.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -775,7 +775,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pybotx"
-version = "0.45.1"
+version = "0.46.0"
 description = "A python library for interacting with eXpress BotX API"
 category = "main"
 optional = false
@@ -791,7 +791,7 @@ typing-extensions = ">=3.7.4,<5.0.0"
 
 [[package]]
 name = "pybotx-smart-logger"
-version = "0.9.1"
+version = "0.9.2"
 description = "Shows logs when you need it"
 category = "main"
 optional = false
@@ -799,7 +799,7 @@ python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
 fastapi = ">=0.70.0,<0.75.0"
-pybotx = ">=0.45.1,<0.46.0"
+pybotx = ">=0.46.0,<0.47.0"
 
 [[package]]
 name = "pycodestyle"
@@ -1252,7 +1252,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "d91c5832754697e33c8d2f3a7aebe3d9ec80d8d2fd639351f8a99e0fc18583d8"
+content-hash = "0b3aa05b0fea4d718125f88c745abc679b14753ee4db03ae85064b9a975c7fc5"
 
 [metadata.files]
 add-trailing-comma = []

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -10,7 +10,7 @@ authors = []
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 
-pybotx = "~0.45.1"
+pybotx = "~0.46.0"
 pybotx-smart-logger = "~0.9.1"
 
 fastapi = "~0.74.1"


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
