### PR TITLE
chore: Bump pybotx version to 0.49.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -783,7 +783,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pybotx"
-version = "0.48.0"
+version = "0.49.0"
 description = "A python library for interacting with eXpress BotX API"
 category = "main"
 optional = false
@@ -799,7 +799,7 @@ typing-extensions = ">=3.7.4,<5.0.0"
 
 [[package]]
 name = "pybotx-smart-logger"
-version = "0.9.4"
+version = "0.9.5"
 description = "Shows logs when you need it"
 category = "main"
 optional = false
@@ -807,7 +807,7 @@ python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
 fastapi = ">=0.70.0,<0.75.0"
-pybotx = ">=0.44.1,<0.49.0"
+pybotx = ">=0.44.1,<0.50.0"
 
 [[package]]
 name = "pycodestyle"
@@ -1264,7 +1264,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "2ebfe3809419d1e10f58cdf858c58fbb550b05b75bd8ef595fc57797a8cfa3b7"
+content-hash = "0384b43839b9e753f6a50cbb6c5c4fae8ca81a6e2252d90d616ba1f2bcbd7bcb"
 
 [metadata.files]
 add-trailing-comma = []

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -10,8 +10,8 @@ authors = []
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 
-pybotx = "~0.48.0"
-pybotx-smart-logger = "~0.9.4"
+pybotx = "~0.49.0"
+pybotx-smart-logger = "~0.9.5"
 
 fastapi = "~0.74.1"
 uvicorn = { version = "~0.17.5", extras = ["standart"] }


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
