### PR TITLE
fix: Default queue name cause errors in SAQ

### DIFF
--- a/app/{% if add_worker %}worker{% endif %}/worker.py.jinja
+++ b/app/{% if add_worker %}worker{% endif %}/worker.py.jinja
@@ -39,7 +39,7 @@ async def healthcheck(_: SaqCtx) -> Literal[True]:
     return True
 
 
-queue = Queue.from_url(app_settings.REDIS_DSN)
+queue = Queue(aioredis.from_url(app_settings.REDIS_DSN), name="{{bot_project_name}}")
 
 settings = {
     "queue": queue,


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
