### PR TITLE
fix: use database connection pool and close all connections when app is shutting down

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from app.api.routers import router
 from app.bot.bot import get_bot
 from app.caching.callback_redis_repo import CallbackRedisRepo
 from app.caching.redis_repo import RedisRepo
-from app.db.sqlalchemy import build_db_session_factory
+from app.db.sqlalchemy import build_db_session_factory, close_db_connections
 from app.resources import strings
 from app.settings import settings
 
@@ -44,6 +44,9 @@ async def shutdown(application: FastAPI) -> None:
     # -- Redis --
     redis_client: aioredis.Redis = application.state.redis
     await redis_client.close()
+
+    # -- Database --
+    await close_db_connections()
 
 
 def get_application(raise_bot_exceptions: bool = False) -> FastAPI:

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,8 @@ per-file-ignores =
     app/services/answer_error.py:WPS110,WPS211,WPS230
 # too many imported names
     app/bot/commands/common.py:WPS235
+# names shadowing
+    app/db/sqlalchemy.py:WPS442
 
 no-accept-encodings = True
 inline-quotes = double


### PR DESCRIPTION
Изменены настройки подключения к Postgres:

- для настройки пула подключений используется `AsyncAdaptedQueuePool` вместо синхронного `QueuePool`;
- все запросы к базе при обработке команды ботом делаются внутри одной транзакции (`scopefunc=current_task`);
- при остановке бота закрываются все подключения к базе.

# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
