### PR TITLE
feat: Add hidden command that shows project version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,10 @@ jobs:
 
       - name: Install copier
         run: |
-          pip install copier
+          pip install copier==7.1.0
           pip install copier-templates-extensions
+          # hardcode pydantic version to avoid dependency conflict with copier
+          pip install pydantic==1.10.2
 
       - name: Test image
         env:
@@ -37,7 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10"]
 
     services:
       postgres:
@@ -68,9 +70,12 @@ jobs:
 
       - name: Install copier
         run: |
-          pip install copier
+          pip install copier==7.1.0
           pip install copier-templates-extensions
+          # hardcode pydantic version to avoid dependency conflict with copier
+          pip install pydantic==1.10.2
           python -m copier --defaults . bot-example
+
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -112,7 +117,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout
@@ -120,8 +125,10 @@ jobs:
 
       - name: Install copier
         run: |
-          pip install copier
+          pip install copier==7.1.0
           pip install copier-templates-extensions
+          # hardcode pydantic version to avoid dependency conflict with copier
+          pip install pydantic==1.10.2
           python -m copier --defaults . bot-example
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/app/bot/commands/common.py
+++ b/app/bot/commands/common.py
@@ -1,6 +1,7 @@
 """Handlers for default bot commands and system events."""
 
 from os import environ
+from subprocess import PIPE, STDOUT, run
 
 from pybotx import (
     Bot,
@@ -60,3 +61,11 @@ async def git_commit_sha(message: IncomingMessage, bot: Bot) -> None:
     """Show git commit SHA."""
 
     await bot.answer_message(environ.get("GIT_COMMIT_SHA", "<undefined>"))
+
+
+@collector.command("/_debug:version", visible=False)
+async def build_version(message: IncomingMessage, bot: Bot) -> None:
+    """Show app version."""
+    cmd = "poetry version --short"
+    output = run(cmd.split(), stdout=PIPE, stderr=STDOUT, text=True).stdout
+    await bot.answer_message(output)

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,8 @@ per-file-ignores =
 # too many args
 # wrong var name
     app/services/answer_error.py:WPS110,WPS211,WPS230
-# too many imported names
-    app/bot/commands/common.py:WPS235
+# too many imported names, subprocess usage
+    app/bot/commands/common.py:WPS235,S404,S603
 # names shadowing
 # `%` string formatting
     app/db/sqlalchemy.py:WPS442,WPS323


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved

Использовал `subprocess.run` вместо `os.system`, поскольку в последнем случае нельзя вернуть stdout.

Хотелось бы, чтобы эту фичу было легко притащить в уже существующие проекты, а также чтобы она работала при локальной разработке. Поэтому решил не задействовать пайплайн.

P.S. в copier подняли версию pydantic до v2 и сломали проект. Пришлось временно захардкодить версии