### PR TITLE
ci: Drop worker container on botstest.stop

### DIFF
--- a/{% if from_ccsteam %}.gitlab-ci.yml{% endif %}.jinja
+++ b/{% if from_ccsteam %}.gitlab-ci.yml{% endif %}.jinja
@@ -163,6 +163,9 @@ deploy.botstest.stop:
   extends: deploy.botstest
   script:
     - docker rm -f ${CONTAINER_NAME} || true
+    {% if add_worker -%}
+    - docker rm -f ${CONTAINER_NAME} ${CONTAINER_NAME}-worker || true
+    {%- endif %}  
     - psql -c "select pg_terminate_backend(pid) from pg_stat_activity \
       where datname = '${POSTGRES_DB}';" postgres || true
     - psql -c "drop database \"${POSTGRES_DB}\"" postgres || true


### PR DESCRIPTION
# Checklist

- [x] I've generated a new bot from the bot-template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `/help` command
  - [x] Bot suggests available commands
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
